### PR TITLE
[APPC-104/transfer-eth] - correct a bug when sending eth

### DIFF
--- a/app/src/main/java/com/asf/wallet/entity/TransactionBuilder.java
+++ b/app/src/main/java/com/asf/wallet/entity/TransactionBuilder.java
@@ -34,8 +34,10 @@ public class TransactionBuilder implements Parcelable {
 
   public TransactionBuilder(@NonNull TokenInfo tokenInfo) {
     contractAddress(tokenInfo.address).decimals(tokenInfo.decimals)
-        .symbol(tokenInfo.symbol)
-        .shouldSendToken(true);
+        .symbol(tokenInfo.symbol);
+    if (!tokenInfo.symbol.equals("ETH")) {
+      shouldSendToken(true);
+    }
     chainId = NO_CHAIN_ID;
   }
 


### PR DESCRIPTION
correct a bug where the value used when sending eth was always 0