### PR TITLE
[APPC 429] Air drop submit button disabled when removing pace on text

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/ui/airdrop/AirdropFragment.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/airdrop/AirdropFragment.java
@@ -70,9 +70,9 @@ public class AirdropFragment extends DaggerFragment implements AirdropView {
       }
 
       @Override public void onTextChanged(CharSequence s, int start, int before, int count) {
-        if (before == 0 && count > 0) {
+        if (!submitButton.isEnabled() && s.length() > 0) {
           submitButton.setEnabled(true);
-        } else if (before > 0 && count == 0) {
+        } else if (submitButton.isEnabled() && s.length() == 0) {
           submitButton.setEnabled(false);
         }
       }


### PR DESCRIPTION
Updated logic to handle text being added and removed from edit text on air drop layout